### PR TITLE
feat: add RPM target format for Fedora/RHEL/openSUSE

### DIFF
--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -50,7 +50,7 @@ compose.desktop {
         jvmArgs("-Dapple.awt.application.appearance=system", "-Dapple.awt.enableTemplateImages=true")
 
         nativeDistributions {
-            targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
+            targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb, TargetFormat.Rpm)
 
             packageName = "Tempo Timer"
             packageVersion = System.getenv("DESKTOP_PACKAGE_VERSION")?.takeIf { it.isNotBlank() } ?: "1.0.0"
@@ -64,7 +64,6 @@ compose.desktop {
             macOS {
                 iconFile.set(project.file("nativeDistributions/macOS/icon.icns"))
                 infoPlist {
-
                 }
                 infoPlist {
                     extraKeysRawXml = project.file("nativeDistributions/macOS/Info.plist").readText()


### PR DESCRIPTION
## Summary

Adds `TargetFormat.Rpm` to the native distribution targets, enabling packaging
for RPM-based Linux distributions (Fedora, RHEL, CentOS, openSUSE).

Previously only `.deb`, `.dmg` and `.msi` were produced. Users on Fedora and
other RPM-based distros had no native package and had to use the `.deb` via
`alien` or run from source.

## Build

```bash
./gradlew :desktopApp:packageRpm
# output: desktopApp/build/compose/binaries/main/rpm/tempo-timer-1.0.0-1.x86_64.rpm

Tested on
- Fedora 43, x86_64